### PR TITLE
Use seeded random generation

### DIFF
--- a/controllers/mariadbconsumer_controller.go
+++ b/controllers/mariadbconsumer_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -326,14 +327,15 @@ func truncateString(str string, num int) string {
 
 var alphaNumeric = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
 var dnsCompliantAlphaNumeric = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func randSeq(n int, dns bool) string {
 	b := make([]rune, n)
 	for i := range b {
 		if dns {
-			b[i] = dnsCompliantAlphaNumeric[rand.Intn(len(dnsCompliantAlphaNumeric))]
+			b[i] = dnsCompliantAlphaNumeric[seededRand.Intn(len(dnsCompliantAlphaNumeric))]
 		} else {
-			b[i] = alphaNumeric[rand.Intn(len(alphaNumeric))]
+			b[i] = alphaNumeric[seededRand.Intn(len(alphaNumeric))]
 		}
 	}
 	return string(b)


### PR DESCRIPTION
The likely hood of two services being the same name in the same namespace, or two databases being the same name are low, this seeded random change reduces the possibility of the same random strings being generated if the pod restarts.