### PR TITLE
use actual list of grants instead of "ALL"

### DIFF
--- a/controllers/mariadb/mariadbconsumer_controller.go
+++ b/controllers/mariadb/mariadbconsumer_controller.go
@@ -381,9 +381,9 @@ func createDatabaseIfNotExist(provider mariadbv1.MariaDBProviderSpec, consumer m
 	case "azure":
 		userName := strings.Split(consumer.Spec.Consumer.Username, "@")
 		// hostName := strings.Split(provider.Hostname, ".")
-		grantUser = fmt.Sprintf("GRANT ALL ON `%s`.* TO `%s`@'%%';", consumer.Spec.Consumer.Database, userName[0])
+		grantUser = fmt.Sprintf("GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON `%s`.* TO `%s`@'%%';", consumer.Spec.Consumer.Database, userName[0])
 	default:
-		grantUser = fmt.Sprintf("GRANT ALL ON `%s`.* TO `%s`@'%%';", consumer.Spec.Consumer.Database, consumer.Spec.Consumer.Username)
+		grantUser = fmt.Sprintf("GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON `%s`.* TO `%s`@'%%';", consumer.Spec.Consumer.Database, consumer.Spec.Consumer.Username)
 	}
 	_, err = db.Exec(grantUser)
 	if err != nil {


### PR DESCRIPTION
some managed database providers (like mariadb-rds) do not allow to set `GRANT ALL` for security reasons and require a specific list of Grants.
The provided Grants are basically all permissions a user can have, see https://mariadb.com/kb/en/grant/#global-privileges