### PR TITLE
bumping memory limit to 50Mi

### DIFF
--- a/charts/dbaas-operator/templates/deployment.yaml
+++ b/charts/dbaas-operator/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 30Mi
+              memory: 50Mi
             requests:
               cpu: 100m
               memory: 20Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/test-resources/operator.yaml
+++ b/test-resources/operator.yaml
@@ -354,7 +354,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
the operator was using 31Mi on startup which on some clusters was causing a CrashLoop Backoff