### PR TITLE
feat: add http handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY handlers/ handlers/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,6 +5,19 @@ metadata:
     control-plane: controller-manager
   name: system
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: controller-backend
+  name: controller-backend
+spec:
+  selector:
+    control-plane: controller-manager
+  ports:
+  - name: backend
+    port: 5000
+    targetPort: backend
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,11 +42,14 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 5000
+          name: backend
         resources:
           limits:
             cpu: 100m
-            memory: 50Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 10

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/google/uuid v1.1.1
+	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.3.0
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -141,7 +141,6 @@ github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -158,6 +157,8 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v0.0.0-20190222133341-cfaf5686ec79/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -235,7 +236,6 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -275,7 +275,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -332,7 +331,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -369,7 +367,6 @@ golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -391,7 +388,6 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -427,7 +423,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/handlers/main.go
+++ b/handlers/main.go
@@ -18,8 +18,8 @@ import (
 const (
 	// ContentType name of the header that defines the format of the reply
 	ContentType = "Content-Type"
-	// DBaaSHeader name of the header that contains if this has been served by dbaas
-	DBaaSHeader = "X-DBaaS"
+	// DBaaSEnvironmentType name of the header that contains if this has been served by dbaas
+	DBaaSEnvironmentType = "X-DBaaS-Environment-Type"
 	// CacheControl name of the header that defines the cache control config
 	CacheControl = "Cache-Control"
 )
@@ -70,14 +70,14 @@ func (h *Client) mariaDBHandler(w http.ResponseWriter, r *http.Request) {
 	opLog := h.Log.WithValues("dbaas-operator", "mariadb")
 	providers := &mariadbv1.MariaDBProviderList{}
 
-	w.Header().Set(ContentType, "text/plain")
-	w.Header().Set(DBaaSHeader, "true")
+	w.Header().Set(ContentType, "application/json")
+	w.Header().Set(DBaaSEnvironmentType, environmentType)
 	w.Header().Set(CacheControl, "private,no-store")
 
 	if err := h.Client.List(ctx, providers); err != nil {
-		opLog.Info(fmt.Sprintf("Unable to get any providers"))
-		w.WriteHeader(404)
-		fmt.Fprintln(w, "notfound")
+		opLog.Info(fmt.Sprintf("Unable to get any providers, error was: %s", err.Error()))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, fmt.Sprintf(`{"result":{"found":false},"error":"%s"}`, err.Error()))
 		return
 	}
 	hasProvider := false
@@ -89,10 +89,11 @@ func (h *Client) mariaDBHandler(w http.ResponseWriter, r *http.Request) {
 	if hasProvider {
 		opLog.Info(fmt.Sprintf("Providers for %s exist", environmentType))
 		w.WriteHeader(200)
-		fmt.Fprintln(w, "found")
+		fmt.Fprintln(w, `{"result":{"found":true}}`)
 	} else {
-		w.WriteHeader(404)
-		fmt.Fprintln(w, "notfound")
+		opLog.Info(fmt.Sprintf("No providers for %s exist", environmentType))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, fmt.Sprintf(`{"result":{"found":false},"error":"no providers for dbaas environment %s"}`, environmentType))
 	}
 }
 
@@ -104,14 +105,14 @@ func (h *Client) mongoDBHandler(w http.ResponseWriter, r *http.Request) {
 	opLog := h.Log.WithValues("dbaas-operator", "mongodb")
 	providers := &mongodbv1.MongoDBProviderList{}
 
-	w.Header().Set(ContentType, "text/plain")
-	w.Header().Set(DBaaSHeader, "true")
+	w.Header().Set(ContentType, "application/json")
+	w.Header().Set(DBaaSEnvironmentType, environmentType)
 	w.Header().Set(CacheControl, "private,no-store")
 
 	if err := h.Client.List(ctx, providers); err != nil {
-		opLog.Info(fmt.Sprintf("Unable to get any providers"))
-		w.WriteHeader(404)
-		fmt.Fprintln(w, "notfound")
+		opLog.Info(fmt.Sprintf("Unable to get any providers, error was: %s", err.Error()))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, fmt.Sprintf(`{"result":{"found":false},"error":"%s"}`, err.Error()))
 		return
 	}
 	hasProvider := false
@@ -123,10 +124,11 @@ func (h *Client) mongoDBHandler(w http.ResponseWriter, r *http.Request) {
 	if hasProvider {
 		opLog.Info(fmt.Sprintf("Providers for %s exist", environmentType))
 		w.WriteHeader(200)
-		fmt.Fprintln(w, "found")
+		fmt.Fprintln(w, `{"result":{"found":true}}`)
 	} else {
-		w.WriteHeader(404)
-		fmt.Fprintln(w, "notfound")
+		opLog.Info(fmt.Sprintf("No providers for %s exist", environmentType))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, fmt.Sprintf(`{"result":{"found":false},"error":"no providers for dbaas environment %s"}`, environmentType))
 	}
 }
 
@@ -138,14 +140,14 @@ func (h *Client) postgresHandler(w http.ResponseWriter, r *http.Request) {
 	opLog := h.Log.WithValues("dbaas-operator", "postgres")
 	providers := &postgresv1.PostgreSQLProviderList{}
 
-	w.Header().Set(ContentType, "text/plain")
-	w.Header().Set(DBaaSHeader, "true")
+	w.Header().Set(ContentType, "application/json")
+	w.Header().Set(DBaaSEnvironmentType, environmentType)
 	w.Header().Set(CacheControl, "private,no-store")
 
 	if err := h.Client.List(ctx, providers); err != nil {
-		opLog.Info(fmt.Sprintf("Unable to get any providers"))
-		w.WriteHeader(404)
-		fmt.Fprintln(w, "notfound")
+		opLog.Info(fmt.Sprintf("Unable to get any providers, error was: %s", err.Error()))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, fmt.Sprintf(`{"result":{"found":false},"error":"%s"}`, err.Error()))
 		return
 	}
 	hasProvider := false
@@ -157,9 +159,10 @@ func (h *Client) postgresHandler(w http.ResponseWriter, r *http.Request) {
 	if hasProvider {
 		opLog.Info(fmt.Sprintf("Providers for %s exist", environmentType))
 		w.WriteHeader(200)
-		fmt.Fprintln(w, "found")
+		fmt.Fprintln(w, `{"result":{"found":true}}`)
 	} else {
-		w.WriteHeader(404)
-		fmt.Fprintln(w, "notfound")
+		opLog.Info(fmt.Sprintf("No providers for %s exist", environmentType))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, fmt.Sprintf(`{"result":{"found":false},"error":"no providers for dbaas environment %s"}`, environmentType))
 	}
 }

--- a/handlers/main.go
+++ b/handlers/main.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/gorilla/mux"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	mariadbv1 "github.com/amazeeio/dbaas-operator/apis/mariadb/v1"
+	mongodbv1 "github.com/amazeeio/dbaas-operator/apis/mongodb/v1"
+	postgresv1 "github.com/amazeeio/dbaas-operator/apis/postgres/v1"
+)
+
+const (
+	// ContentType name of the header that defines the format of the reply
+	ContentType = "Content-Type"
+	// DBaaSHeader name of the header that contains if this has been served by dbaas
+	DBaaSHeader = "X-DBaaS"
+	// CacheControl name of the header that defines the cache control config
+	CacheControl = "Cache-Control"
+)
+
+var (
+	favicon = "data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+// Client is the client structure for http handlers.
+type Client struct {
+	Client ctrlClient.Client
+	Log    logr.Logger
+	Debug  bool
+	// RequestCount    *prometheus.CounterVec
+	// RequestDuration *prometheus.HistogramVec
+}
+
+func faviconHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "image/x-icon")
+	w.Header().Set("Cache-Control", "public, max-age=7776000")
+	fmt.Fprintln(w, fmt.Sprintf("%s\n", favicon))
+}
+
+// Run runs the http server.
+func Run(h *Client, setupLog logr.Logger) {
+	r := mux.NewRouter()
+	r.HandleFunc("/favicon.ico", faviconHandler)
+	r.HandleFunc("/mariadb/{environment}", h.mariaDBHandler)
+	r.HandleFunc("/mongodb/{environment}", h.mongoDBHandler)
+	r.HandleFunc("/postgres/{environment}", h.postgresHandler)
+
+	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := http.ListenAndServe(fmt.Sprintf(":5000"), r)
+	if err != nil {
+		setupLog.Error(err, "unable to start http server")
+		os.Exit(1)
+	}
+}
+
+func (h *Client) mariaDBHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	environmentType := vars["environment"]
+
+	ctx := context.Background()
+	opLog := h.Log.WithValues("dbaas-operator", "mariadb")
+	providers := &mariadbv1.MariaDBProviderList{}
+
+	w.Header().Set(ContentType, "text/plain")
+	w.Header().Set(DBaaSHeader, "true")
+	w.Header().Set(CacheControl, "private,no-store")
+
+	if err := h.Client.List(ctx, providers); err != nil {
+		opLog.Info(fmt.Sprintf("Unable to get any providers"))
+		w.WriteHeader(404)
+		fmt.Fprintln(w, "notfound")
+		return
+	}
+	hasProvider := false
+	for _, provider := range providers.Items {
+		if provider.Spec.Environment == environmentType {
+			hasProvider = true
+		}
+	}
+	if hasProvider {
+		opLog.Info(fmt.Sprintf("Providers for %s exist", environmentType))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, "found")
+	} else {
+		w.WriteHeader(404)
+		fmt.Fprintln(w, "notfound")
+	}
+}
+
+func (h *Client) mongoDBHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	environmentType := vars["environment"]
+
+	ctx := context.Background()
+	opLog := h.Log.WithValues("dbaas-operator", "mongodb")
+	providers := &mongodbv1.MongoDBProviderList{}
+
+	w.Header().Set(ContentType, "text/plain")
+	w.Header().Set(DBaaSHeader, "true")
+	w.Header().Set(CacheControl, "private,no-store")
+
+	if err := h.Client.List(ctx, providers); err != nil {
+		opLog.Info(fmt.Sprintf("Unable to get any providers"))
+		w.WriteHeader(404)
+		fmt.Fprintln(w, "notfound")
+		return
+	}
+	hasProvider := false
+	for _, provider := range providers.Items {
+		if provider.Spec.Environment == environmentType {
+			hasProvider = true
+		}
+	}
+	if hasProvider {
+		opLog.Info(fmt.Sprintf("Providers for %s exist", environmentType))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, "found")
+	} else {
+		w.WriteHeader(404)
+		fmt.Fprintln(w, "notfound")
+	}
+}
+
+func (h *Client) postgresHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	environmentType := vars["environment"]
+
+	ctx := context.Background()
+	opLog := h.Log.WithValues("dbaas-operator", "postgres")
+	providers := &postgresv1.PostgreSQLProviderList{}
+
+	w.Header().Set(ContentType, "text/plain")
+	w.Header().Set(DBaaSHeader, "true")
+	w.Header().Set(CacheControl, "private,no-store")
+
+	if err := h.Client.List(ctx, providers); err != nil {
+		opLog.Info(fmt.Sprintf("Unable to get any providers"))
+		w.WriteHeader(404)
+		fmt.Fprintln(w, "notfound")
+		return
+	}
+	hasProvider := false
+	for _, provider := range providers.Items {
+		if provider.Spec.Environment == environmentType {
+			hasProvider = true
+		}
+	}
+	if hasProvider {
+		opLog.Info(fmt.Sprintf("Providers for %s exist", environmentType))
+		w.WriteHeader(200)
+		fmt.Fprintln(w, "found")
+	} else {
+		w.WriteHeader(404)
+		fmt.Fprintln(w, "notfound")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ import (
 	mariadbcontroller "github.com/amazeeio/dbaas-operator/controllers/mariadb"
 	mongodbcontroller "github.com/amazeeio/dbaas-operator/controllers/mongodb"
 	postgrescontroller "github.com/amazeeio/dbaas-operator/controllers/postgres"
+
+	"github.com/amazeeio/dbaas-operator/handlers"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -140,6 +142,14 @@ func main() {
 		}
 	}
 	// +kubebuilder:scaffold:builder
+
+	h := &handlers.Client{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers-http").WithName("DBaaS"),
+	}
+	// +kubebuilder:scaffold:builder
+	setupLog.Info("starting http server")
+	go handlers.Run(h, setupLog)
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/operator-test.sh
+++ b/operator-test.sh
@@ -456,7 +456,7 @@ echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Add a provider"
 kubectl apply -f test-resources/mariadb/provider.yaml
 
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider"
-kubectl exec -it busybox -- wget -q -O - http://backend.dbaas-operator-system.svc/mariadb/test
+kubectl exec -it busybox -- wget -q -O - http://controller-backend.dbaas-operator-system.svc/mariadb/test
 
 echo -e "${GREEN}====>${YELLOW}MariaDB: ${NOCOLOR} Test blank consumer"
 echo "Test adding a blank consumer with a specific environment type."

--- a/operator-test.sh
+++ b/operator-test.sh
@@ -451,12 +451,36 @@ add_delete_consumer_failure () {
 start_up
 build_deploy_operator
 
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider"
+echo "Test checking the dbaas-operator http handler for a specific environment type."
+echo "This test should return found true or false, true if there are any usable providers, false if there are none"
+DBAAS_HTTP_RESULT=$(kubectl exec -it busybox -- wget -q -O - http://dbaas-operator-controller-backend.dbaas-operator-system.svc:5000/mariadb/non-existent)
+if [ "$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)" != "false" ]; then
+    echo "provider http check returned found when it should have been not found"
+    check_operator_log
+    tear_down
+    exit 1
+fi
+R_FOUND=$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)
+R_ERROR=$(echo ${DBAAS_HTTP_RESULT} | jq -r .error)
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider result: ${R_FOUND} / ${R_ERROR}"
 
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Add a provider"
 kubectl apply -f test-resources/mariadb/provider.yaml
 
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider"
-kubectl exec -it busybox -- wget -q -O - http://controller-backend.dbaas-operator-system.svc/mariadb/test
+echo "Test checking the dbaas-operator http handler for a specific environment type."
+echo "This test should return found true or false, true if there are any usable providers, false if there are none"
+DBAAS_HTTP_RESULT=$(kubectl exec -it busybox -- wget -q -O - http://dbaas-operator-controller-backend.dbaas-operator-system.svc:5000/mariadb/test)
+if [ "$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)" != "true" ]; then
+    R_ERROR=$(echo ${DBAAS_HTTP_RESULT} | jq -r .error)
+    echo "provider http check returned not found when it should have been found: ${R_ERROR}"
+    check_operator_log
+    tear_down
+    exit 1
+fi
+R_FOUND=$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider result: ${R_FOUND}"
 
 echo -e "${GREEN}====>${YELLOW}MariaDB: ${NOCOLOR} Test blank consumer"
 echo "Test adding a blank consumer with a specific environment type."
@@ -490,6 +514,20 @@ check_operator_log | grep mariadbconsumer-testing-fail1
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Add an azure provider"
 kubectl apply -f test-resources/mariadb/provider-azure.yaml
 
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider"
+echo "Test checking the dbaas-operator http handler for a specific environment type."
+echo "This test should return found true or false, true if there are any usable providers, false if there are none"
+DBAAS_HTTP_RESULT=$(kubectl exec -it busybox -- wget -q -O - http://dbaas-operator-controller-backend.dbaas-operator-system.svc:5000/mariadb/azure)
+if [ "$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)" != "true" ]; then
+    R_ERROR=$(echo ${DBAAS_HTTP_RESULT} | jq -r .error)
+    echo "provider http check returned not found when it should have been found: ${R_ERROR}"
+    check_operator_log
+    tear_down
+    exit 1
+fi
+R_FOUND=$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider result: ${R_FOUND}"
+
 echo -e "${GREEN}====>${YELLOW}MariaDB: ${NOCOLOR} Test blank azure consumer"
 echo "Test adding a blank consumer with a specific environment type, but for azure"
 echo "This test should create the database and user, and the associated services randomly"
@@ -501,6 +539,20 @@ check_operator_log | grep mariadbconsumer-testing-azure
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Add multi providers"
 kubectl apply -f test-resources/mariadb/provider-multi.yaml
 # testing multiple providers allows testing of the logic to ensure that the correct provider is chosen.
+
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider"
+echo "Test checking the dbaas-operator http handler for a specific environment type."
+echo "This test should return found true or false, true if there are any usable providers, false if there are none"
+DBAAS_HTTP_RESULT=$(kubectl exec -it busybox -- wget -q -O - http://dbaas-operator-controller-backend.dbaas-operator-system.svc:5000/mariadb/multi)
+if [ "$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)" != "true" ]; then
+    R_ERROR=$(echo ${DBAAS_HTTP_RESULT} | jq -r .error)
+    echo "provider http check returned not found when it should have been found: ${R_ERROR}"
+    check_operator_log
+    tear_down
+    exit 1
+fi
+R_FOUND=$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider result: ${R_FOUND}"
 
 echo -e "${GREEN}====>${YELLOW}MariaDB: ${NOCOLOR} Test multi providers"
 echo "Test adding a blank consumer with a specific environment type, but of a type that has multiple providers available"
@@ -552,6 +604,20 @@ echo -e "${GREEN}====>${LIGHTBLUE}PostgreSQL: ${NOCOLOR} Add a provider"
 kubectl apply -f test-resources/postgres/provider.yaml
 kubectl get postgresqlprovider/postgreprovider-testing -o yaml
 
+echo -e "${GREEN}==>${LIGHTBLUE}PostgreSQL: ${NOCOLOR} Check provider"
+echo "Test checking the dbaas-operator http handler for a specific environment type."
+echo "This test should return found true or false, true if there are any usable providers, false if there are none"
+DBAAS_HTTP_RESULT=$(kubectl exec -it busybox -- wget -q -O - http://dbaas-operator-controller-backend.dbaas-operator-system.svc:5000/postgres/test)
+if [ "$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)" != "true" ]; then
+    R_ERROR=$(echo ${DBAAS_HTTP_RESULT} | jq -r .error)
+    echo "provider http check returned not found when it should have been found: ${R_ERROR}"
+    check_operator_log
+    tear_down
+    exit 1
+fi
+R_FOUND=$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)
+echo -e "${GREEN}==>${LIGHTBLUE}PostgreSQL: ${NOCOLOR} Check provider result: ${R_FOUND}"
+
 echo -e "${GREEN}====>${LIGHTBLUE}PostgreSQL: ${NOCOLOR} Test blank consumer"
 add_delete_consumer_psql test-resources/postgres/consumer.yaml psqlconsumer-testing
 echo -e "${YELLOW}====>${LIGHTBLUE}PostgreSQL: ${NOCOLOR} Blank consumer logs"
@@ -568,6 +634,20 @@ echo -e "${GREEN}====>${MAGENTA}MongoDB: ${NOCOLOR} Add a provider"
 kubectl apply -f test-resources/mongodb/provider.yaml
 kubectl get mongodbprovider/mongodbprovider-testing -o yaml
 
+echo -e "${GREEN}==>${MAGENTA}MongoDB: ${NOCOLOR} Check provider"
+echo "Test checking the dbaas-operator http handler for a specific environment type."
+echo "This test should return found true or false, true if there are any usable providers, false if there are none"
+DBAAS_HTTP_RESULT=$(kubectl exec -it busybox -- wget -q -O - http://dbaas-operator-controller-backend.dbaas-operator-system.svc:5000/mongodb/test)
+if [ "$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)" != "true" ]; then
+    R_ERROR=$(echo ${DBAAS_HTTP_RESULT} | jq -r .error)
+    echo "provider http check returned not found when it should have been found: ${R_ERROR}"
+    check_operator_log
+    tear_down
+    exit 1
+fi
+R_FOUND=$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)
+echo -e "${GREEN}==>${MAGENTA}MongoDB: ${NOCOLOR} Check provider result: ${R_FOUND}"
+
 echo -e "${GREEN}====>${MAGENTA}MongoDB: ${NOCOLOR} Test blank consumer"
 add_delete_consumer_mongodb test-resources/mongodb/consumer.yaml mongodbconsumer-testing
 echo -e "${YELLOW}====>${MAGENTA}MongoDB: ${NOCOLOR} Blank consumer logs"
@@ -583,6 +663,20 @@ echo -e "${GREEN}==>${MAGENTA}MongoDB: ${NOCOLOR} Test MongoDB TLS"
 echo -e "${GREEN}====>${MAGENTA}MongoDB: ${NOCOLOR} Add a TLS provider"
 kubectl apply -f test-resources/mongodb/provider-tls.yaml
 kubectl get mongodbprovider/mongodbprovider-tls-testing -o yaml
+
+echo -e "${GREEN}==>${MAGENTA}MongoDB: ${NOCOLOR} Check provider"
+echo "Test checking the dbaas-operator http handler for a specific environment type."
+echo "This test should return found true or false, true if there are any usable providers, false if there are none"
+DBAAS_HTTP_RESULT=$(kubectl exec -it busybox -- wget -q -O - http://dbaas-operator-controller-backend.dbaas-operator-system.svc:5000/mongodb/tls-test)
+if [ "$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)" != "true" ]; then
+    R_ERROR=$(echo ${DBAAS_HTTP_RESULT} | jq -r .error)
+    echo "provider http check returned not found when it should have been found: ${R_ERROR}"
+    check_operator_log
+    tear_down
+    exit 1
+fi
+R_FOUND=$(echo ${DBAAS_HTTP_RESULT} | jq -r .result.found)
+echo -e "${GREEN}==>${MAGENTA}MongoDB: ${NOCOLOR} Check provider result: ${R_FOUND}"
 
 echo -e "${GREEN}====>${MAGENTA}MongoDB: ${NOCOLOR} Test blank TLS consumer"
 add_delete_consumer_mongodb_tls test-resources/mongodb/consumer-tls.yaml mongodbconsumer-tls-testing

--- a/operator-test.sh
+++ b/operator-test.sh
@@ -78,8 +78,6 @@ mongodb_start_check () {
   done
 }
 
-
-
 mongodb_tls_start_check () {
   until $(docker-compose exec -T local-dbaas-mongo-tls-provider mongo --tls --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames mongodb://root:password@mongodb.172.17.0.1.nip.io:27018/  --quiet --eval 'db.getMongo().getDBNames().forEach(function(db){print(db)})' | grep -q admin)
   do
@@ -119,6 +117,9 @@ start_up () {
 }
 
 build_deploy_operator () {
+  echo -e "${GREEN}==>${GREEN}BusyBox: ${NOCOLOR} Add a busybox pod"
+  kubectl apply -f test-resources/busybox.yaml
+
   echo -e "${GREEN}==>${NOCOLOR} Build and deploy operator"
   make docker-build IMG=${OPERATOR_IMAGE}
   kind load docker-image ${OPERATOR_IMAGE} --name ${KIND_NAME}
@@ -139,9 +140,6 @@ build_deploy_operator () {
     exit 1
   fi
   done
-
-  echo -e "${GREEN}==>${GREEN}BusyBox: ${NOCOLOR} Add a busybox pod"
-  kubectl apply -f test-resources/busybox.yaml
 }
 
 check_services () {
@@ -452,6 +450,7 @@ add_delete_consumer_failure () {
 
 start_up
 build_deploy_operator
+
 
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Add a provider"
 kubectl apply -f test-resources/mariadb/provider.yaml

--- a/operator-test.sh
+++ b/operator-test.sh
@@ -139,6 +139,9 @@ build_deploy_operator () {
     exit 1
   fi
   done
+
+  echo -e "${GREEN}==>${GREEN}BusyBox: ${NOCOLOR} Add a busybox pod"
+  kubectl apply -f test-resources/busybox.yaml
 }
 
 check_services () {
@@ -449,9 +452,6 @@ add_delete_consumer_failure () {
 
 start_up
 build_deploy_operator
-
-echo -e "${GREEN}==>${GREEN}BusyBox: ${NOCOLOR} Add a busybox pod"
-kubectl apply -f test-resources/busybox.yaml
 
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Add a provider"
 kubectl apply -f test-resources/mariadb/provider.yaml

--- a/operator-test.sh
+++ b/operator-test.sh
@@ -450,8 +450,14 @@ add_delete_consumer_failure () {
 start_up
 build_deploy_operator
 
+echo -e "${GREEN}==>${GREEN}BusyBox: ${NOCOLOR} Add a busybox pod"
+kubectl apply -f test-resources/busybox.yaml
+
 echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Add a provider"
 kubectl apply -f test-resources/mariadb/provider.yaml
+
+echo -e "${GREEN}==>${YELLOW}MariaDB: ${NOCOLOR} Check provider"
+kubectl exec -it busybox -- wget -q -O - http://backend.dbaas-operator-system.svc/mariadb/test
 
 echo -e "${GREEN}====>${YELLOW}MariaDB: ${NOCOLOR} Test blank consumer"
 echo "Test adding a blank consumer with a specific environment type."

--- a/test-resources/busybox.yaml
+++ b/test-resources/busybox.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+    name: busybox
+  restartPolicy: Always


### PR DESCRIPTION
Examples:
```
# check for a provider of environment `production`
curl -s http://dbaas-operator.svc:5000/mariadb/production
{"result":{"found":true}}

# check for a provider of environment `nonexistent`
curl -s http://dbaas-operator.svc:5000/mariadb/nonexistent
{"result":{"found":false},"error":"no providers for dbaas environment nonexistent"}
```

Closes #41 