### PR TITLE
feat: support to disable provisioning on a provider

### DIFF
--- a/controllers/mariadb/mariadbconsumer_controller.go
+++ b/controllers/mariadb/mariadbconsumer_controller.go
@@ -573,6 +573,12 @@ func (r *MariaDBConsumerReconciler) checkMariaDBProviders(provider *mariadbv1.Ma
 	var nameSpaceName string
 	lowestTableCount := -1
 	for _, v := range providersList.Items {
+		if noProvision, ok := v.Labels["dbaas.amazee.io/no-provision"]; ok {
+			if noProvision == "true" {
+				// don't provision against this provider
+				continue
+			}
+		}
 		if v.Spec.Environment == mariaDBConsumer.Spec.Environment {
 			// Form a temporary connection object.
 			mDBProvider := mariadbv1.MariaDBProviderSpec{

--- a/controllers/mongodb/mongodbconsumer_controller.go
+++ b/controllers/mongodb/mongodbconsumer_controller.go
@@ -519,6 +519,12 @@ func (r *MongoDBConsumerReconciler) checkMongoDBProviders(provider *MongoDBProvi
 	var nameSpaceName string
 	lowestTableCount := -1
 	for _, v := range providersList.Items {
+		if noProvision, ok := v.Labels["dbaas.amazee.io/no-provision"]; ok {
+			if noProvision == "true" {
+				// don't provision against this provider
+				continue
+			}
+		}
 		if v.Spec.Environment == mongoDBConsumer.Spec.Environment {
 			// Form a temporary connection object.
 			mDBProvider := MongoDBProviderInfo{

--- a/controllers/postgres/postgresqlconsumer_controller.go
+++ b/controllers/postgres/postgresqlconsumer_controller.go
@@ -463,6 +463,12 @@ func (r *PostgreSQLConsumerReconciler) checkPostgresSQLProviders(provider *postg
 	var nameSpaceName string
 	lowestTableCount := -1
 	for _, v := range providersList.Items {
+		if noProvision, ok := v.Labels["dbaas.amazee.io/no-provision"]; ok {
+			if noProvision == "true" {
+				// don't provision against this provider
+				continue
+			}
+		}
 		if v.Spec.Environment == postgresSQLConsumer.Spec.Environment {
 			// Form a temporary connection object.
 			mDBProvider := postgresv1.PostgreSQLProviderSpec{


### PR DESCRIPTION
Sometimes you may want to prevent a provider from being used for provisioning, but allow for deprovisioning to still take place.

Adding the label `dbaas.amazee.io/no-provision=true` to the provider will remove it from being a provisioning target.