### PR TITLE
fix: grant public schema privileges for PostgreSQL 15+

### DIFF
--- a/controllers/postgres/postgresqlconsumer_controller.go
+++ b/controllers/postgres/postgresqlconsumer_controller.go
@@ -366,6 +366,40 @@ func createDatabaseIfNotExist(provider postgresv1.PostgreSQLProviderSpec, consum
 		return fmt.Errorf("Unable to create database %s : %v", consumer.Spec.Consumer.Database, err)
 	}
 
+	// PostgreSQL 15+ no longer grants CREATE on the public schema to PUBLIC by
+	// default, so the new user cannot create objects in its database even though
+	// it owns the database. Grant the required privileges on the public schema.
+	// Schema grants are per-database, so this needs a fresh connection to the
+	// newly created database (the connection above is to the "postgres" database).
+	err = grantPublicSchema(provider, consumer, userName[0])
+	if err != nil {
+		dropErr := dropDatabase(db, consumer.Spec.Consumer.Database)
+		if dropErr != nil {
+			return fmt.Errorf("unable drop database after failed schema grant: %v", dropErr)
+		}
+		dropErr = dropUser(db, consumer, provider)
+		if dropErr != nil {
+			return fmt.Errorf("unable drop user after failed schema grant: %v", dropErr)
+		}
+		return fmt.Errorf("unable to grant public schema privileges to user %s: %v", userName[0], err)
+	}
+
+	return nil
+}
+
+func grantPublicSchema(provider postgresv1.PostgreSQLProviderSpec, consumer postgresv1.PostgreSQLConsumer, userName string) error {
+	sslMode := "disable"
+	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s "+"password=%s dbname=%s sslmode=%s", provider.Hostname, provider.Port, provider.Username, provider.Password, consumer.Spec.Consumer.Database, sslMode)
+	db, err := sql.Open("postgres", psqlInfo)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	grantSchema := fmt.Sprintf("GRANT ALL ON SCHEMA public TO \"%s\";", userName)
+	_, err = db.Exec(grantSchema)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

PostgreSQL 15 [no longer grants `CREATE` on the `public` schema to `PUBLIC`](https://stackoverflow.com/a/75876944) by default. As a result, a provisioned consumer user cannot create objects (tables, etc.) in its own database — even though it owns the database — on managed Postgres setups (Azure, RDS, ...) where the admin role isn't a true superuser.

This adds a step in `createDatabaseIfNotExist`: after `CREATE DATABASE ... OWNER`, open a fresh connection to the newly created database and `GRANT ALL ON SCHEMA public` to the consumer user. Schema grants are per-database, so the existing connection (to the `postgres` database) can't be reused.

`GRANT ALL` covers both `CREATE` and `USAGE` from the linked workaround in a single statement. On failure the database and user are rolled back, matching the existing error handling in the function.

Fixes #75

## Notes

- This runs for all Postgres versions, not just 15+. It's harmless on older versions and avoids a server-version check.
- No test added — the provisioning path requires a live Postgres and isn't unit-covered by the current suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)